### PR TITLE
Fixed version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^5.5|^7.0",
         "guzzlehttp/guzzle": "~6.0",
-        "wyrihaximus/react-guzzle-http-client": "^3.0.1|^3.1"
+        "wyrihaximus/react-guzzle-http-client": "^3.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0|^5.0",


### PR DESCRIPTION
`^3.0.1` already includes `^3.1` as a subset. Are you thinking of `~` rather than `^` by any chance?
