### PR TITLE
Updated HttpClientAdapter so it supports react/http-client 0.4 and 0.5

### DIFF
--- a/src/HttpClientAdapter.php
+++ b/src/HttpClientAdapter.php
@@ -9,7 +9,9 @@ use React\Dns\Resolver\Factory as DnsFactory;
 use React\Dns\Resolver\Resolver as DnsResolver;
 use React\EventLoop\LoopInterface;
 use React\HttpClient\Client as HttpClient;
+use React\HttpClient\Client;
 use React\HttpClient\Factory as HttpClientFactory;
+use React\Socket\Connector;
 use WyriHaximus\React\Guzzle\HttpClient\RequestFactory;
 
 class HttpClientAdapter
@@ -66,8 +68,20 @@ class HttpClientAdapter
         if (!($httpClient instanceof HttpClient)) {
             $this->setDnsResolver($this->dnsResolver);
 
-            $factory = new HttpClientFactory();
-            $httpClient = $factory->create($this->loop, $this->dnsResolver);
+            if (class_exists('React\HttpClient\Factory')) {
+                $factory = new HttpClientFactory();
+                $httpClient = $factory->create($this->loop, $this->dnsResolver);
+            } else {
+                $httpClient = new Client(
+                    $this->loop,
+                    new Connector(
+                        $this->loop,
+                        [
+                            'dns' => $this->dnsResolver,
+                        ]
+                    )
+                );
+            }
         }
 
         $this->httpClient = $httpClient;


### PR DESCRIPTION
With the recent update in `wyrihaximus/react-guzzle-http-client` supports was added for `react/http-client` `v0.5`. But this causes an error in this package as came up with #24 

Fixes / Closes #24 