### PR TITLE
Load system's nameserver as default instead of google

### DIFF
--- a/src/HttpClientAdapter.php
+++ b/src/HttpClientAdapter.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use React\Dns\Resolver\Factory as DnsFactory;
 use React\Dns\Resolver\Resolver as DnsResolver;
+use React\Dns\Config\Config as DnsConfig;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\Timer\TimerInterface;
 use React\HttpClient\Client as HttpClient;
@@ -104,7 +105,9 @@ class HttpClientAdapter
     {
         if (!($dnsResolver instanceof DnsResolver)) {
             $dnsResolverFactory = new DnsFactory();
-            $dnsResolver = $dnsResolverFactory->createCached('8.8.8.8', $this->loop);
+            $config = DnsConfig::loadSystemConfigBlocking();
+            $nameserver = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+            $dnsResolver = $dnsResolverFactory->createCached($nameserver, $this->loop);
         }
 
         $this->dnsResolver = $dnsResolver;

--- a/tests/HttpClientAdapterTest.php
+++ b/tests/HttpClientAdapterTest.php
@@ -13,6 +13,7 @@ namespace WyriHaximus\React\Tests\GuzzlePsr7;
 use Clue\React\Buzz\Message\ResponseException;
 use GuzzleHttp\Psr7\Request;
 use Phake;
+use React\Dns\Config\Config as DnsConfig;
 use React\Dns\Resolver\Factory as ResolverFactory;
 use React\EventLoop\Factory;
 use React\Promise\Deferred;
@@ -49,7 +50,9 @@ class HttpClientAdapterTest extends \PHPUnit_Framework_TestCase
         $this->requestArray = [];
         $this->loop = Factory::create();
         $this->requestFactory = Phake::mock('WyriHaximus\React\Guzzle\HttpClient\RequestFactory');
-        $this->dnsResolver = (new ResolverFactory())->createCached('8.8.8.8', $this->loop);
+        $config = DnsConfig::loadSystemConfigBlocking();
+        $nameserver = $config->nameservers ? reset($config->nameservers) : '8.8.8.8';
+        $this->dnsResolver = (new ResolverFactory())->createCached($nameserver, $this->loop);
         if (class_exists('React\HttpClient\Factory')) {
             $this->httpClient = Phake::partialMock(
                 'React\HttpClient\Client',


### PR DESCRIPTION
Hi guys,

I've been working on performance improvements of my service and I've noticed that all DNS resolutions were going through Google's nameserver instead of going through whatever is specified in the /etc/resolv.conf. Then I found out that the adapter was initializing React Resolver with 8.8.8.8 as nameserver. In my opinion, the library should only impose Google's nameserver if it can't find any specification on the system's level or if explicitly requested. I would like to propose this change.

Thank you!